### PR TITLE
GROOVY-9859: Groovy3 doesn't parse a function property when there's a…

### DIFF
--- a/src/main/antlr/GroovyParser.g4
+++ b/src/main/antlr/GroovyParser.g4
@@ -267,7 +267,7 @@ memberDeclaration[int t]
  *  ct  9: script, other see the comment of classDeclaration
  */
 methodDeclaration[int t, int ct]
-    :   modifiersOpt typeParameters? returnType[$ct]?
+    :   modifiersOpt typeParameters? (returnType[$ct] nls)?
         methodName formalParameters
         (
             DEFAULT nls elementValue

--- a/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
+++ b/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
@@ -23,6 +23,7 @@ import groovy.transform.CompileStatic
 import org.apache.groovy.parser.antlr4.util.ASTComparatorCategory
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.FieldNode
+import org.codehaus.groovy.ast.GenericsType
 import org.codehaus.groovy.ast.MethodNode
 import org.codehaus.groovy.ast.Parameter
 import org.codehaus.groovy.ast.PropertyNode
@@ -439,6 +440,7 @@ class GroovyParserTest extends GroovyTestCase {
         doTest('bugs/BUG-GROOVY-8913.groovy');
         doRunAndTestAntlr4('bugs/BUG-GROOVY-8991.groovy');
         doTest('bugs/BUG-GROOVY-9399.groovy');
+        doTest('bugs/BUG-GROOVY-9859.groovy', [GenericsType])
     }
 
     void "test groovy core - GROOVY-9427"() {

--- a/src/test/resources/bugs/BUG-GROOVY-9859.groovy
+++ b/src/test/resources/bugs/BUG-GROOVY-9859.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+public synchronized ImmutableMap<String,Pair<String,Double>>
+a(
+        List<String> params,
+        List<String> columnMapping)
+{
+    return null;
+}
+
+public class Pair<T, U> {}
+public class ImmutableMap<T, U> {}


### PR DESCRIPTION
… new line between return value and function name