### PR TITLE
fix: added `duplicatesStrategy` for tasks with Jar to avoid build error `no duplicate handling strategy`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ apply plugin: 'antlr'
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
+// added duplicatesStrategy for tasks with Jar to avoid: Execution failed for task ':jar'.: Entry org/codehaus/groovy/antlr/java/JavaLexer$1.class is a duplicate but no duplicate handling strategy has been set.
+tasks.withType(Jar).all {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }


### PR DESCRIPTION
On Windows 10 Pro v10.0.19045 Build 19045 x64-based PC, I was getting the following build error in jdk-1.8.0_352, jdk-11.0.2, and jdk-17.0.2, so I added `duplicatesStrategy` for tasks with Jar to avoid error:

```
Execution failed for task ':jar'.
> Entry org/codehaus/groovy/antlr/java/JavaLexer$1.class is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.4.2/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
```

